### PR TITLE
Bhn verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,13 @@ You can see in this case I piped the output of the `show` sub-command to the `jq
 ### Evaluating a proof
 
 `evaluate <hash_id>` calculates and displays the expected values for each anchor in the proof.
-Adding `--btc` or `-b` will return the previous outpoint hash for the first input of the evaluated bitcoin proofs.
-This can be useful for evaluating proofs with light clients.
+Adding `--btc` or `-b` will return the txid of the anchor transaction.
 
 ```
 chp evaluate b640f9f0-3661-11e9-9c57-018b108544a2
 
 b640f9f0-3661-11e9-9c57-018b108544a2 | cal | 2755298 | ab1dc08a1950ade9d4d603c90d655307eb765905148f6e18eddeb64ca241b7b4
-b640f9f0-3661-11e9-9c57-018b108544a2 | btc | 564116 | af81bc00748ed3beab4f08ad16b33bb88aefdc0a283eb4446cf8d83b38ea7133 | 1 | 6a630dbd22cf54f2da91396e48f025cf1f154ffa8eb7d9642b969da39921d6ea
+b640f9f0-3661-11e9-9c57-018b108544a2 | btc | 564116 | af81bc00748ed3beab4f08ad16b33bb88aefdc0a283eb4446cf8d83b38ea7133 | 7cdcefb56c2ec3230b2edb2ff5d1adf4a8acf4525850e1f0248b803cfe96dd02
 
 ```
 

--- a/lib/bhn/execute.js
+++ b/lib/bhn/execute.js
@@ -2,13 +2,11 @@ const getClient = require('./utils/getClient')
 const testConnection = require('./utils/testConnection')
 
 exports.command = 'execute <method> [options..]'
-exports.desc =
-  'fire an arbitrary rpc method to the bitcoin header node. e.g. `chp bhn execute getpeerinfo`'
+exports.desc = 'fire an arbitrary rpc method to the bitcoin header node. e.g. `chp bhn execute getpeerinfo`'
 exports.builder = function(yargs) {
   yargs.positional('method', {
     type: 'string',
-    describe:
-      'rpc method to execute. subsequent strings are sent as arguments for the rpc method'
+    describe: 'rpc method to execute. subsequent strings are sent as arguments for the rpc method'
   })
 }
 exports.handler = async function(argv) {

--- a/lib/bhn/utils/getInfo.js
+++ b/lib/bhn/utils/getInfo.js
@@ -8,14 +8,9 @@ async function getInfo(options) {
     return info
   } catch (e) {
     let message = new Error(e.message)
-    if (e.code === 'ENOTFOUND')
-      message = new Error(
-        `Problem connecting to bitcoin header node at ${uri}: ${e.message}`
-      )
+    if (e.code === 'ENOTFOUND') message = new Error(`Problem connecting to bitcoin header node at ${uri}: ${e.message}`)
     else if (e.code === 'ECONNREFUSED') {
-      message = new Error(
-        `No Bitcoin node found running at ${uri}. Run \`chp bhn start\` to run one locally. `
-      )
+      message = new Error(`No Bitcoin node found running at ${uri}. Run \`chp bhn start\` to run one locally. `)
     }
     return message
   }

--- a/lib/bhn/utils/index.js
+++ b/lib/bhn/utils/index.js
@@ -1,0 +1,6 @@
+'use strict'
+
+exports.getClient = require('./getClient')
+exports.getConfig = require('./getConfig')
+exports.getInfo = require('./getInfo')
+exports.testConnection = require('./testConnection')

--- a/lib/bhn/utils/testConnection.js
+++ b/lib/bhn/utils/testConnection.js
@@ -1,12 +1,15 @@
 const chalk = require('chalk')
 const getInfo = require('./getInfo')
 
-async function testConnection(options) {
+async function testConnection(options, checkSynced) {
   let message = await getInfo(options)
   if (message instanceof Error) {
+    console.log(chalk.red('There was a problem reaching the bitcoin node:'), message.message)
+    return false
+  } else if (message && message.chain.progress < 1 && checkSynced) {
     console.log(
-      chalk.red('There was a problem reaching the bitcoin node:'),
-      message.message
+      chalk`{red Bitcoin node is not fully synced. Please wait until sync is complete:}
+${+message.chain.progress.toFixed(6) * 100}% completed`
     )
     return false
   }

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -44,10 +44,7 @@ async function executeAsync(yargs, argv) {
     // parameters are valid, open storage and process evaluate
     try {
       let hashDb = await storage.connectAsync()
-      let hashItem = await hashDb.findOneAsync(
-        { _id: hashIdNode },
-        { _id: 1, nodeUri: 1 }
-      )
+      let hashItem = await hashDb.findOneAsync({ _id: hashIdNode }, { _id: 1, nodeUri: 1 })
       if (!hashItem) {
         throw new Error('hash_id_node not found')
       }
@@ -95,10 +92,7 @@ async function executeAsync(yargs, argv) {
       let updateTasks = []
       for (let x = 0; x < proofHandleSegments.length; x++) {
         updateTasks.push(async () => {
-          return updateCmd.updateHashesByHashIdNodeAsync(
-            hashDb,
-            proofHandleSegments[x]
-          )
+          return updateCmd.updateHashesByHashIdNodeAsync(hashDb, proofHandleSegments[x])
         })
       }
       if (updateTasks.length > 0) {
@@ -156,10 +150,7 @@ function displayOutputResults(resultsArray, outputObj, quiet, json, btc) {
     }
     if (btc && result.raw_btc_tx) {
       tx = TX.fromRaw(result.raw_btc_tx, 'hex')
-      // 1 prevout should be sufficient to verify anchor
-      // but show the count to provide additional information
-      output.prevout_count = tx.inputs.length
-      output.prevout_1 = tx.inputs[0].prevout.rhash()
+      output.txid = tx.txid()
     }
     outputObj.addSuccessResult(output)
   }
@@ -181,8 +172,7 @@ async function EvaluateProofs(proofs, btc) {
         let index = response.findIndex(
           anchor =>
             // find anchor response where type is btc and confirm id matches
-            anchor.type === 'btc' &&
-            anchor.hash_id_node === btcResponse.hash_id_node
+            anchor.type === 'btc' && anchor.hash_id_node === btcResponse.hash_id_node
         )
         // add btcResponse info to anchor response
         response[index] = { ...btcResponse, ...response[index] }

--- a/lib/output-builder.js
+++ b/lib/output-builder.js
@@ -46,10 +46,12 @@ class OutputBuilder {
         for (let x = 0; x < this.output.results.length; x++) {
           let lineData = []
           for (let key in this.output.results[x]) {
+            let result = this.output.results[x][key]
             if (key === 'success') continue
-            if (key === 'anchors_invalid' && this.output.results[x][key].length === 0) continue
-            if (key === 'proof') this.output.results[x][key] = JSON.stringify(this.output.results[x][key])
-            lineData.push(this.output.results[x][key])
+            if (key === 'anchors_invalid' && result.length === 0) continue
+            if (key === 'anchors_valid' && result.length === 0) continue
+            if (key === 'proof') result = JSON.stringify(result)
+            lineData.push(result)
           }
           console.log(lineData.join(' | '))
         }

--- a/lib/output-builder.js
+++ b/lib/output-builder.js
@@ -47,15 +47,8 @@ class OutputBuilder {
           let lineData = []
           for (let key in this.output.results[x]) {
             if (key === 'success') continue
-            if (
-              key === 'anchors_invalid' &&
-              this.output.results[x][key].length === 0
-            )
-              continue
-            if (key === 'proof')
-              this.output.results[x][key] = JSON.stringify(
-                this.output.results[x][key]
-              )
+            if (key === 'anchors_invalid' && this.output.results[x][key].length === 0) continue
+            if (key === 'proof') this.output.results[x][key] = JSON.stringify(this.output.results[x][key])
             lineData.push(this.output.results[x][key])
           }
           console.log(lineData.join(' | '))

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -17,6 +17,9 @@ const OutputBuilder = require('./output-builder.js')
 const parallel = require('async-await-parallel')
 const chp = require('chainpoint-client')
 const retry = require('async-retry')
+const { mapKeys, camelCase } = require('lodash')
+
+const { getClient, testConnection } = require('./bhn/utils')
 
 // The time until a proof expires from storage
 const PROOF_EXPIRE_MINUTES = 1440
@@ -65,12 +68,15 @@ async function executeAsync(yargs, argv) {
 
       let verifyResults
       try {
-        verifyResults = await VerifyProofs([
-          {
-            proof: hashItem.proof,
-            nodeUri: targetNodeUri
-          }
-        ])
+        verifyResults = await VerifyProofs(
+          [
+            {
+              proof: hashItem.proof,
+              nodeUri: targetNodeUri
+            }
+          ],
+          argv
+        )
       } catch (error) {
         console.error(`ERROR : Could not verify proof`)
         return
@@ -129,7 +135,7 @@ async function executeAsync(yargs, argv) {
 
     let verifyResults
     try {
-      verifyResults = await VerifyProofs(proofData)
+      verifyResults = await VerifyProofs(proofData, argv)
     } catch (error) {
       console.error(`ERROR : Could not verify proofs`)
       return
@@ -146,6 +152,7 @@ function displayOutputResults(resultsArray, outputObj, quiet, json) {
       validAnchors.push(resultsArray[x].anchors_valid[y].type)
     }
     let invalidAnchors = []
+    // console.log(resultsArray)
     for (let y = 0; y < resultsArray[x].anchors_invalid.length; y++) {
       let result
       if (resultsArray[x].anchors_invalid[y].status === 'unknown') {
@@ -166,58 +173,92 @@ function displayOutputResults(resultsArray, outputObj, quiet, json) {
   outputObj.display(quiet, json)
 }
 
-async function VerifyProofs(proofData) {
+async function VerifyProofs(proofData, options) {
   let verifyResponse
   try {
-    // Create a lookup table of proofs grouped by their common nodeURI
-    // These groups will be verified in separate calls because the chp.verifyProofs
-    // command accepts one URI for a group of proofs.
-    let proofDataURIGroups = proofData.reduce((results, proofDataItem) => {
-      if (results[proofDataItem.nodeUri] === undefined) {
-        results[proofDataItem.nodeUri] = [proofDataItem.proof]
-      } else {
-        results[proofDataItem.nodeUri].push(proofDataItem.proof)
-      }
-      return results
-    }, {})
+    // TODO: How do we want to handle cal proofs? Skip or
 
-    // define a function for verifying a set of proofs sharing a common nodeUri
-    let verifySetAsync = async proofDataSet => {
-      let firstAttempt = true
-      return retry(
-        async () => {
-          let targetURI = firstAttempt ? proofDataSet.nodeUri : null
-          firstAttempt = false
-          return chp.verifyProofs(proofDataSet.proofs, targetURI)
-        },
-        {
-          retries: 5, // The maximum amount of times to retry the operation. Default is 10
-          factor: 1, // The exponential factor to use. Default is 2
-          minTimeout: 10, // The number of milliseconds before starting the first retry. Default is 1000
-          maxTimeout: 10
-        }
-      )
-    }
+    // first test a connection to a bhn node based on passed in options
+    let hasConnection = await testConnection(options, true)
+    if (hasConnection) {
+      let client = getClient(options)
+      let { network } = await client.getInfo()
+      if (network === 'main') network = 'mainnet'
+      let uri = `${client.ssl ? 'https:' : 'http:'}//${client.host}:${client.port}`
+      console.log(`Verifying btc proofs against ${network} bitcoin node at ${uri}...`)
 
-    // create a verify task for each set of proofs with a unique nodeUri
-    let verifyTasks = []
-    for (var nodeUri in proofDataURIGroups) {
-      if (proofDataURIGroups.hasOwnProperty(nodeUri)) {
-        let task = verifySetAsync({
-          proofs: proofDataURIGroups[nodeUri],
-          nodeUri: nodeUri
+      let proofs = proofData.map(item => item.proof)
+      let evaluatedProofs = chp.evaluateProofs(proofs)
+      let verifyTasks = evaluatedProofs
+        .filter(proof => proof.type === 'btc' && proof.anchor_id)
+        .map(async proof => {
+          try {
+            // get header from bitcoin node
+            let header = await client.getBlock(parseInt(proof.anchor_id, 10))
+
+            // check if there was a header returned and it matches the expected value in the proof
+            let verified = header && header.merkleRoot === proof.expected_value
+            let verifiedProof = { ...proof, verified }
+
+            // add verification time stamp
+            verifiedProof.verified_at = verified ? new Date().toISOString().slice(0, 19) + 'Z' : null
+            return mapKeys(verifiedProof, (v, k) => camelCase(k))
+          } catch (err) {
+            console.error(`Problem validating proof with bitcoin node: ${err.message}`)
+          }
         })
-        verifyTasks.push(task)
-      }
-    }
+      verifyResponse = await Promise.all(verifyTasks)
+    } else {
+      console.log(`Could not connect to bitcoin node. Verifying proofs against chainpoint node.`)
+      // Create a lookup table of proofs grouped by their common nodeURI
+      // These groups will be verified in separate calls because the chp.verifyProofs
+      // command accepts one URI for a group of proofs.
+      let proofDataURIGroups = proofData.reduce((results, proofDataItem) => {
+        if (results[proofDataItem.nodeUri] === undefined) {
+          results[proofDataItem.nodeUri] = [proofDataItem.proof]
+        } else {
+          results[proofDataItem.nodeUri].push(proofDataItem.proof)
+        }
+        return results
+      }, {})
 
-    // execute and await thew results of all verify tasks
-    let verifyTasksResults = await Promise.all(verifyTasks)
-    // combine all veridy results into a single verify results array
-    verifyResponse = verifyTasksResults.reduce((results, response) => {
-      results.push(...response)
-      return results
-    }, [])
+      // define a function for verifying a set of proofs sharing a common nodeUri
+      let verifySetAsync = async proofDataSet => {
+        let firstAttempt = true
+        return retry(
+          async () => {
+            let targetURI = firstAttempt ? proofDataSet.nodeUri : null
+            firstAttempt = false
+            return chp.verifyProofs(proofDataSet.proofs, targetURI)
+          },
+          {
+            retries: 5, // The maximum amount of times to retry the operation. Default is 10
+            factor: 1, // The exponential factor to use. Default is 2
+            minTimeout: 10, // The number of milliseconds before starting the first retry. Default is 1000
+            maxTimeout: 10
+          }
+        )
+      }
+
+      // create a verify task for each set of proofs with a unique nodeUri
+      let verifyTasks = []
+      for (var nodeUri in proofDataURIGroups) {
+        if (proofDataURIGroups.hasOwnProperty(nodeUri)) {
+          let task = verifySetAsync({
+            proofs: proofDataURIGroups[nodeUri],
+            nodeUri: nodeUri
+          })
+          verifyTasks.push(task)
+        }
+      }
+      // execute and await thew results of all verify tasks
+      let verifyTasksResults = await Promise.all(verifyTasks)
+      // combine all veridy results into a single verify results array
+      verifyResponse = verifyTasksResults.reduce((results, response) => {
+        results.push(...response)
+        return results
+      }, [])
+    }
   } catch (error) {
     console.error(`Could not verify proofs : ${error.message}`)
   }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -43,10 +43,7 @@ async function executeAsync(yargs, argv) {
     // parameters are valid, open storage and process verify
     try {
       let hashDb = await storage.connectAsync()
-      let hashItem = await hashDb.findOneAsync(
-        { _id: hashIdNode },
-        { _id: 1, nodeUri: 1 }
-      )
+      let hashItem = await hashDb.findOneAsync({ _id: hashIdNode }, { _id: 1, nodeUri: 1 })
       if (!hashItem) {
         throw new Error('hash_id_node not found')
       }
@@ -99,10 +96,7 @@ async function executeAsync(yargs, argv) {
       let updateTasks = []
       for (let x = 0; x < proofHandleSegments.length; x++) {
         updateTasks.push(async () => {
-          return updateCmd.updateHashesByHashIdNodeAsync(
-            hashDb,
-            proofHandleSegments[x]
-          )
+          return updateCmd.updateHashesByHashIdNodeAsync(hashDb, proofHandleSegments[x])
         })
       }
       if (updateTasks.length > 0) {
@@ -229,13 +223,8 @@ async function VerifyProofs(proofData) {
   }
 
   // process chp.verifyProofs response, grouping all anchors into single hashItem object
-  let hashItemAnchorGroups = verifyResponse.reduce(function(
-    hashItemsAnchors,
-    verifyResponseItem
-  ) {
-    hashItemsAnchors[verifyResponseItem.hashIdNode] = hashItemsAnchors[
-      verifyResponseItem.hashIdNode
-    ] || {
+  let hashItemAnchorGroups = verifyResponse.reduce(function(hashItemsAnchors, verifyResponseItem) {
+    hashItemsAnchors[verifyResponseItem.hashIdNode] = hashItemsAnchors[verifyResponseItem.hashIdNode] || {
       hash: verifyResponseItem.hash,
       hashIdNode: verifyResponseItem.hashIdNode,
       hashIdCore: verifyResponseItem.hashIdCore,
@@ -253,8 +242,7 @@ async function VerifyProofs(proofData) {
       verifiedAt: verifyResponseItem.verifiedAt
     })
     return hashItemsAnchors
-  },
-  {})
+  }, {})
 
   let verifyResults = []
 


### PR DESCRIPTION
update `chp verify` to check btc anchors against a locally running node

To test:
* start a bhn instance locally with `./chp.js bhn start`. 
  * If you didn't already have one synced, you can start from right before the last checkpoint: `./chp.js bhn start --start-height=52400` (there's a bug in bhn that makes a later start height fail, but should be able to fix this relatively easily).
* If you have any local proofs anchored to btc mainnet, then you can run `./chp.js verify [HASH-ID-NODE]` and it will verify the anchor.
* You can confirm that this was checked against your local node by starting it with `--log-level=debug` and then checking that the `GET /block/[HEIGHT]` was queried in the logs. 
* trying with the `--all` option should also work. Any proofs that are anchored into bitcoin testnet will return invalid. 