### PR TITLE
update chp verify

### DIFF
--- a/chp.js
+++ b/chp.js
@@ -16,9 +16,7 @@ const semver = require('semver')
 const currentVersion = process.version
 let runningValidVersion = semver.gt(currentVersion, '7.6.0')
 if (!runningValidVersion) {
-  console.error(
-    `Chainpoint CLI requires Node v7.6.0 or higher, ${currentVersion} is currently in use`
-  )
+  console.error(`Chainpoint CLI requires Node v7.6.0 or higher, ${currentVersion} is currently in use`)
   process.exit(1)
 }
 

--- a/lib/bhn/get.js
+++ b/lib/bhn/get.js
@@ -3,8 +3,7 @@ const getClient = require('./utils/getClient')
 const testConnection = require('./utils/testConnection')
 
 exports.command = 'get <block-height> [header node options...]'
-exports.desc =
-  'get the header for a block at a certai block. Must point to a running bhn server'
+exports.desc = 'get the header for a block at a certai block. Must point to a running bhn server'
 exports.builder = function(yargs) {
   yargs.positional('block-height', {
     type: 'number',
@@ -30,9 +29,6 @@ Make sure your node is fully synced and the target block is not before the node'
     console.log(`Header for block #${blockHeight}:`)
     console.log(header)
   } catch (e) {
-    console.error(
-      `Problem retrieving header for block ${blockHeight}:`,
-      e.message
-    )
+    console.error(`Problem retrieving header for block ${blockHeight}:`, e.message)
   }
 }

--- a/lib/bhn/stop.js
+++ b/lib/bhn/stop.js
@@ -12,11 +12,7 @@ exports.handler = async function(argv) {
 
   try {
     let client = getClient(argv)
-    console.log(
-      `Stopping bitcoin header node at ${client.ssl ? 'https:' : 'http:'}//${
-        client.host
-      }:${client.port}...`
-    )
+    console.log(`Stopping bitcoin header node at ${client.ssl ? 'https:' : 'http:'}//${client.host}:${client.port}...`)
     await client.execute('stop')
     console.log('Node is stopped.')
   } catch (e) {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -176,17 +176,18 @@ function displayOutputResults(resultsArray, outputObj, quiet, json) {
 async function VerifyProofs(proofData, options) {
   let verifyResponse
   try {
-    // TODO: How do we want to handle cal proofs? Skip or
-
     // first test a connection to a bhn node based on passed in options
     let hasConnection = await testConnection(options, true)
+    // group proofs by node_uri (necessary for making the cal requests)
+    // evaluate all proofs
+    // get top priority proof for each hash_id_node (btc > cal)
     if (hasConnection) {
       let client = getClient(options)
       let { network } = await client.getInfo()
       if (network === 'main') network = 'mainnet'
       let uri = `${client.ssl ? 'https:' : 'http:'}//${client.host}:${client.port}`
       console.log(`Verifying btc proofs against ${network} bitcoin node at ${uri}...`)
-
+      console.log('proofData:', proofData)
       let proofs = proofData.map(item => item.proof)
       let evaluatedProofs = chp.evaluateProofs(proofs)
       let verifyTasks = evaluatedProofs
@@ -221,24 +222,6 @@ async function VerifyProofs(proofData, options) {
         }
         return results
       }, {})
-
-      // define a function for verifying a set of proofs sharing a common nodeUri
-      let verifySetAsync = async proofDataSet => {
-        let firstAttempt = true
-        return retry(
-          async () => {
-            let targetURI = firstAttempt ? proofDataSet.nodeUri : null
-            firstAttempt = false
-            return chp.verifyProofs(proofDataSet.proofs, targetURI)
-          },
-          {
-            retries: 5, // The maximum amount of times to retry the operation. Default is 10
-            factor: 1, // The exponential factor to use. Default is 2
-            minTimeout: 10, // The number of milliseconds before starting the first retry. Default is 1000
-            maxTimeout: 10
-          }
-        )
-      }
 
       // create a verify task for each set of proofs with a unique nodeUri
       let verifyTasks = []
@@ -330,6 +313,24 @@ async function VerifyProofs(proofData, options) {
   })
 
   return verifyResults
+}
+
+// define a function for verifying a set of proofs sharing a common nodeUri
+async function verifySetAsync(proofDataSet) {
+  let firstAttempt = true
+  return retry(
+    async () => {
+      let targetURI = firstAttempt ? proofDataSet.nodeUri : null
+      firstAttempt = false
+      return chp.verifyProofs(proofDataSet.proofs, targetURI)
+    },
+    {
+      retries: 5, // The maximum amount of times to retry the operation. Default is 10
+      factor: 1, // The exponential factor to use. Default is 2
+      minTimeout: 10, // The number of milliseconds before starting the first retry. Default is 1000
+      maxTimeout: 10
+    }
+  )
 }
 
 module.exports = {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -250,7 +250,7 @@ async function VerifyProofs(proofData, options) {
     // execute and await thew results of all verify tasks
     let verifyTasksResults = await Promise.all(verifyTasks)
 
-    // combine all veridy results into a single verify results array
+    // combine all verify results into a single verify results array
     verifyResponse = verifyTasksResults.reduce((results, response) => {
       if (!response) return results
       if (Array.isArray(response)) results.push(...response)

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -138,7 +138,6 @@ async function executeAsync(yargs, argv) {
     try {
       verifyResults = await VerifyProofs(proofData, argv)
     } catch (error) {
-      console.log('error.stack:', error.stack)
       console.error(`ERROR: Could not verify proofs. ${error.message}`)
       return
     }
@@ -208,10 +207,10 @@ async function VerifyProofs(proofData, options) {
 
     // next we need to create the async validation tasks
     // there will be two loops to accomplish this
-    // first go through each nodeUris array of proofs and for those proofs
+    // first go through each nodeURI's array of proofs and for those proofs,
     // if we have a bitcoin node connection, we need to determine if each proof
     // has a btc anchor by looping through each proof, evaluating/parsing, and then
-    // if it does, verify against the bitcoin node otherwise add a chp node verification task
+    // if it does, verify against the bitcoin node. Otherwise, add a chp node verification task
     for (var nodeUri in proofDataURIGroups) {
       // if we don't have access to a bitcoin node (`!hasBhnConnection`)
       if (!hasBhnConnection && proofDataURIGroups.hasOwnProperty(nodeUri)) {
@@ -264,7 +263,6 @@ async function VerifyProofs(proofData, options) {
 
   // process chp.verifyProofs response, grouping all anchors into single hashItem object
   let hashItemAnchorGroups = verifyResponse.reduce(function(hashItemsAnchors, verifyResponseItem) {
-    // console.log('verifyResponseItem.hashIdNode:', verifyResponseItem.hashIdNode)
     hashItemsAnchors[verifyResponseItem.hashIdNode] = hashItemsAnchors[verifyResponseItem.hashIdNode] || {
       hash: verifyResponseItem.hash,
       hashIdNode: verifyResponseItem.hashIdNode,

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -14,10 +14,11 @@ const utils = require('./utils.js')
 const storage = require('./storage.js')
 const updateCmd = require('./update.js')
 const OutputBuilder = require('./output-builder.js')
+const chalk = require('chalk')
 const parallel = require('async-await-parallel')
 const chp = require('chainpoint-client')
 const retry = require('async-retry')
-const { mapKeys, camelCase } = require('lodash')
+const { mapKeys, camelCase, forEach } = require('lodash')
 
 const { getClient, testConnection } = require('./bhn/utils')
 
@@ -152,7 +153,7 @@ function displayOutputResults(resultsArray, outputObj, quiet, json) {
       validAnchors.push(resultsArray[x].anchors_valid[y].type)
     }
     let invalidAnchors = []
-    // console.log(resultsArray)
+
     for (let y = 0; y < resultsArray[x].anchors_invalid.length; y++) {
       let result
       if (resultsArray[x].anchors_invalid[y].status === 'unknown') {
@@ -177,71 +178,80 @@ async function VerifyProofs(proofData, options) {
   let verifyResponse
   try {
     // first test a connection to a bhn node based on passed in options
-    let hasConnection = await testConnection(options, true)
-    // group proofs by node_uri (necessary for making the cal requests)
-    // evaluate all proofs
-    // get top priority proof for each hash_id_node (btc > cal)
-    if (hasConnection) {
-      let client = getClient(options)
-      let { network } = await client.getInfo()
+    let hasBhnConnection = await testConnection(options, true)
+
+    // Create a lookup table of proofs grouped by their common nodeURI
+    // These groups will be verified in separate calls if no bhn available
+    // because the chp.verifyProofs command accepts one URI for a group of proofs.
+    let proofDataURIGroups = proofData.reduce((results, proofDataItem) => {
+      if (results[proofDataItem.nodeUri] === undefined) {
+        results[proofDataItem.nodeUri] = [proofDataItem.proof]
+      } else {
+        results[proofDataItem.nodeUri].push(proofDataItem.proof)
+      }
+      return results
+    }, {})
+
+    // initialize array of async tasks and setup client
+    let verifyTasks = []
+    let btcClient
+    if (hasBhnConnection) {
+      btcClient = getClient(options)
+      let { network } = await btcClient.getInfo()
       if (network === 'main') network = 'mainnet'
-      let uri = `${client.ssl ? 'https:' : 'http:'}//${client.host}:${client.port}`
+      let uri = `${btcClient.ssl ? 'https:' : 'http:'}//${btcClient.host}:${btcClient.port}`
       console.log(`Verifying btc proofs against ${network} bitcoin node at ${uri}...`)
-      console.log('proofData:', proofData)
-      let proofs = proofData.map(item => item.proof)
-      let evaluatedProofs = chp.evaluateProofs(proofs)
-      let verifyTasks = evaluatedProofs
-        .filter(proof => proof.type === 'btc' && proof.anchor_id)
-        .map(async proof => {
-          try {
-            // get header from bitcoin node
-            let header = await client.getBlock(parseInt(proof.anchor_id, 10))
-
-            // check if there was a header returned and it matches the expected value in the proof
-            let verified = header && header.merkleRoot === proof.expected_value
-            let verifiedProof = { ...proof, verified }
-
-            // add verification time stamp
-            verifiedProof.verified_at = verified ? new Date().toISOString().slice(0, 19) + 'Z' : null
-            return mapKeys(verifiedProof, (v, k) => camelCase(k))
-          } catch (err) {
-            console.error(`Problem validating proof with bitcoin node: ${err.message}`)
-          }
-        })
-      verifyResponse = await Promise.all(verifyTasks)
     } else {
       console.log(`Could not connect to bitcoin node. Verifying proofs against chainpoint node.`)
-      // Create a lookup table of proofs grouped by their common nodeURI
-      // These groups will be verified in separate calls because the chp.verifyProofs
-      // command accepts one URI for a group of proofs.
-      let proofDataURIGroups = proofData.reduce((results, proofDataItem) => {
-        if (results[proofDataItem.nodeUri] === undefined) {
-          results[proofDataItem.nodeUri] = [proofDataItem.proof]
-        } else {
-          results[proofDataItem.nodeUri].push(proofDataItem.proof)
-        }
-        return results
-      }, {})
-
-      // create a verify task for each set of proofs with a unique nodeUri
-      let verifyTasks = []
-      for (var nodeUri in proofDataURIGroups) {
-        if (proofDataURIGroups.hasOwnProperty(nodeUri)) {
-          let task = verifySetAsync({
-            proofs: proofDataURIGroups[nodeUri],
-            nodeUri: nodeUri
-          })
-          verifyTasks.push(task)
-        }
-      }
-      // execute and await thew results of all verify tasks
-      let verifyTasksResults = await Promise.all(verifyTasks)
-      // combine all veridy results into a single verify results array
-      verifyResponse = verifyTasksResults.reduce((results, response) => {
-        results.push(...response)
-        return results
-      }, [])
     }
+
+    // next we need to create the async validation tasks
+    // there will be two loops to accomplish this
+    // first go through each nodeUris array of proofs and for those proofs
+    // if we have a bitcoin node connection, we need to determine if each proof
+    // has a btc anchor by looping through each proof, evaluating/parsing, and then
+    // if it does, verify against the bitcoin node otherwise add a chp node verification task
+    for (var nodeUri in proofDataURIGroups) {
+      // if we don't have access to a bitcoin node (`!hasBhnConnection`)
+      if (!hasBhnConnection && proofDataURIGroups.hasOwnProperty(nodeUri)) {
+        // simply add a new verify async task for the group for each node_uri
+        let task = verifySetAsync({
+          proofs: proofDataURIGroups[nodeUri],
+          nodeUri: nodeUri
+        })
+        verifyTasks.push(task)
+      } else {
+        // otherwise we need to determine if there is a btc anchor to verify
+        forEach(proofDataURIGroups[nodeUri], rawProof => {
+          let task
+          // evaluate/parse each proof with chainpoint-client
+          let proofs = chp.evaluateProofs([rawProof])
+          // if proof has btc type proof
+          let btcAnchorIndex = proofs.findIndex(proof => proof.type === 'btc')
+          // add new task to verify against bitcoin node
+          if (btcAnchorIndex > -1) {
+            task = verifyBtcProof(proofs[btcAnchorIndex], btcClient)
+            verifyTasks.push(task)
+          } else {
+            // otherwise add verifySetAsync task for that (raw) proof
+            task = verifySetAsync({
+              proofs: [rawProof],
+              nodeUri: nodeUri
+            })
+            verifyTasks.push(task)
+          }
+        })
+      }
+    }
+
+    // execute and await thew results of all verify tasks
+    let verifyTasksResults = await Promise.all(verifyTasks)
+    // combine all veridy results into a single verify results array
+    verifyResponse = verifyTasksResults.reduce((results, response) => {
+      if (Array.isArray(response)) results.push(...response)
+      else results.push(response)
+      return results
+    }, [])
   } catch (error) {
     console.error(`Could not verify proofs : ${error.message}`)
   }
@@ -331,6 +341,31 @@ async function verifySetAsync(proofDataSet) {
       maxTimeout: 10
     }
   )
+}
+
+async function verifyBtcProof(proof, client) {
+  if (!client) throw new Error('Must pass a client to verifyBtcProof')
+  try {
+    // get header from bitcoin node
+    let header = await client.getBlock(parseInt(proof.anchor_id, 10))
+
+    // check if there was a header returned and it matches the expected value in the proof
+    let verified = header && header.merkleRoot === proof.expected_value
+    if (!verified && proof.anchor_id >= 1500000) {
+      console.log(
+        chalk`{red NETWORK MISMATCH:} ${proof.hash_id_node} anchored to bitcoin's testnet at height ${
+          proof.anchor_id
+        }, but validating node is running on mainnet`
+      )
+    }
+    let verifiedProof = { ...proof, verified }
+
+    // add verification time stamp
+    verifiedProof.verified_at = verified ? new Date().toISOString().slice(0, 19) + 'Z' : null
+    return mapKeys(verifiedProof, (v, k) => camelCase(k))
+  } catch (err) {
+    console.error(`Problem validating proof with bitcoin node: ${err.message}`)
+  }
 }
 
 module.exports = {

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -20,7 +20,7 @@ const chp = require('chainpoint-client')
 const retry = require('async-retry')
 const { mapKeys, camelCase, forEach } = require('lodash')
 
-const { getClient, testConnection } = require('./bhn/utils')
+const { getClient, testConnection, getInfo } = require('./bhn/utils')
 
 // The time until a proof expires from storage
 const PROOF_EXPIRE_MINUTES = 1440
@@ -138,7 +138,8 @@ async function executeAsync(yargs, argv) {
     try {
       verifyResults = await VerifyProofs(proofData, argv)
     } catch (error) {
-      console.error(`ERROR : Could not verify proofs`)
+      console.log('error.stack:', error.stack)
+      console.error(`ERROR: Could not verify proofs. ${error.message}`)
       return
     }
 
@@ -215,11 +216,14 @@ async function VerifyProofs(proofData, options) {
       // if we don't have access to a bitcoin node (`!hasBhnConnection`)
       if (!hasBhnConnection && proofDataURIGroups.hasOwnProperty(nodeUri)) {
         // simply add a new verify async task for the group for each node_uri
+        let proofs = [...proofDataURIGroups[nodeUri]]
         let task = verifySetAsync({
-          proofs: proofDataURIGroups[nodeUri],
+          proofs,
           nodeUri: nodeUri
         })
-        verifyTasks.push(task)
+        // adding a catch to each task so that in the event that one fails,
+        // it doesn't crash the entire `Promise.all` resolution
+        verifyTasks.push(task.catch(() => catchFailedVerification(proofs)))
       } else {
         // otherwise we need to determine if there is a btc anchor to verify
         forEach(proofDataURIGroups[nodeUri], rawProof => {
@@ -231,14 +235,14 @@ async function VerifyProofs(proofData, options) {
           // add new task to verify against bitcoin node
           if (btcAnchorIndex > -1) {
             task = verifyBtcProof(proofs[btcAnchorIndex], btcClient)
-            verifyTasks.push(task)
+            verifyTasks.push(task.catch(() => catchFailedVerification([rawProof])))
           } else {
             // otherwise add verifySetAsync task for that (raw) proof
             task = verifySetAsync({
               proofs: [rawProof],
               nodeUri: nodeUri
             })
-            verifyTasks.push(task)
+            verifyTasks.push(task.catch(() => catchFailedVerification([rawProof])))
           }
         })
       }
@@ -246,18 +250,21 @@ async function VerifyProofs(proofData, options) {
 
     // execute and await thew results of all verify tasks
     let verifyTasksResults = await Promise.all(verifyTasks)
+
     // combine all veridy results into a single verify results array
     verifyResponse = verifyTasksResults.reduce((results, response) => {
+      if (!response) return results
       if (Array.isArray(response)) results.push(...response)
       else results.push(response)
       return results
     }, [])
   } catch (error) {
-    console.error(`Could not verify proofs : ${error.message}`)
+    console.error(`Could not verify proofs: ${error.message}`)
   }
 
   // process chp.verifyProofs response, grouping all anchors into single hashItem object
   let hashItemAnchorGroups = verifyResponse.reduce(function(hashItemsAnchors, verifyResponseItem) {
+    // console.log('verifyResponseItem.hashIdNode:', verifyResponseItem.hashIdNode)
     hashItemsAnchors[verifyResponseItem.hashIdNode] = hashItemsAnchors[verifyResponseItem.hashIdNode] || {
       hash: verifyResponseItem.hash,
       hashIdNode: verifyResponseItem.hashIdNode,
@@ -335,7 +342,7 @@ async function verifySetAsync(proofDataSet) {
       return chp.verifyProofs(proofDataSet.proofs, targetURI)
     },
     {
-      retries: 5, // The maximum amount of times to retry the operation. Default is 10
+      retries: 2, // The maximum amount of times to retry the operation. Default is 10
       factor: 1, // The exponential factor to use. Default is 2
       minTimeout: 10, // The number of milliseconds before starting the first retry. Default is 1000
       maxTimeout: 10
@@ -351,12 +358,24 @@ async function verifyBtcProof(proof, client) {
 
     // check if there was a header returned and it matches the expected value in the proof
     let verified = header && header.merkleRoot === proof.expected_value
-    if (!verified && proof.anchor_id >= 1500000) {
-      console.log(
-        chalk`{red NETWORK MISMATCH:} ${proof.hash_id_node} anchored to bitcoin's testnet at height ${
-          proof.anchor_id
-        }, but validating node is running on mainnet`
-      )
+    if (!verified) {
+      // want to see if the reason for verification fail is because of a network mismatch b/w
+      // anchor and bhn we are in communication with
+      let {
+        network,
+        chain: { tip }
+      } = await client.getInfo()
+      let anchorNetwork
+      if (proof.anchor_id > tip && network === 'main') anchorNetwork = 'testnet'
+      // an anchor id that is less than 1,200,000 is likely on mainnet since there were no
+      // testnet proofs made before late 2017 and no mainnet blocks will be mined that high until ~2030
+      else if (proof.anchor_id < 1200000) anchorNetwork = 'mainnet'
+      if (anchorNetwork)
+        console.log(
+          chalk`{red NETWORK MISMATCH:} ${proof.hash_id_node} anchored to bitcoin's ${anchorNetwork} at height ${
+            proof.anchor_id
+          }, but validating node is running on ${network}`
+        )
     }
     let verifiedProof = { ...proof, verified }
 
@@ -366,6 +385,16 @@ async function verifyBtcProof(proof, client) {
   } catch (err) {
     console.error(`Problem validating proof with bitcoin node: ${err.message}`)
   }
+}
+
+function catchFailedVerification(proofs) {
+  if (!Array.isArray(proofs)) proofs = [proofs]
+  proofs = chp.evaluateProofs(proofs)
+  return proofs.map(proof => {
+    proof.verified = null
+    proof.verified_at = null
+    return mapKeys(proof, (v, k) => camelCase(k))
+  })
 }
 
 module.exports = {


### PR DESCRIPTION
adds support to do "mixed validation" where the cli will check against chainpoint nodes for proofs that only have cal anchors or when no bitcoin node is available, otherwise only verifies against bitcoin node for btc anchors.