### PR TITLE
update api for passing config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ The CLI also maintains a simple local database that keeps track of
 every hash you submit, and stores and manages Chainpoint proofs
 locally for easy retrieval, export, and verification.
 
+## Backwards Incompatible Changes for V2
+
+- cli arg for passing a custom node server was changed from `--server` and `-s` to `--node-uri` and `-n`.
+  Use `chp --help` for more info
+- To pass connection configs for a bitcoin header node (bhn), preface with a `--bhn-`, e.g. `--bhn-uri`, `--bhn-port`, or `--bhn-api-key`
+
 ## Installation
 
 ### Easy Install
@@ -71,11 +77,11 @@ Commands:
   version   show the CLI version
 
 Options:
-  -s, --server  specify server to use[string] [default: "http://0.0.0.0"]
-  -q, --quiet   suppress all non-error output                            [boolean]
-  -j, --json    format all output as json                                [boolean]
-  -b, --btc     display btc specific information where applicable        [boolean]
-  --help        show help                                                [boolean]
+  -n, --node-uri  specify uri of chainpoint node [string] [default: "http://0.0.0.0"]
+  -q, --quiet   suppress all non-error output                               [boolean]
+  -j, --json    format all output as json                                   [boolean]
+  -b, --btc     display btc specific information where applicable           [boolean]
+  --help        show help                                                   [boolean]
 
 You must specify a command.
 ```
@@ -239,8 +245,8 @@ $ chp submit --help
 Usage: submit [options] (<hash> <hash>... | <hash>,<hash>,... )
 
 Options:
-  -s, --server  specify server to use
-                                  [string] [default: "http://SERVER"]
+  -n, --node-uri  specify uri of chainpoint node
+                                  [string] [default: "http://NODE_URI"]
   -q, --quiet   suppress all non-error output                          [boolean]
   -j, --json    format all output as json                              [boolean]
   --help        show help                                              [boolean]

--- a/cli.js
+++ b/cli.js
@@ -160,26 +160,26 @@ async function startAsync() {
         yargs
           .commandDir('lib/bhn')
           .usage('Usage: bhn <command> [options...]')
-          .option('uri', {
+          .option('bhn-uri', {
             describe:
               'full uri of bitcoin header node. If no port is given, assumed default RPC port for Bitcoin Mainnet (8332)'
           })
-          .option('api-key', {
+          .option('bhn-api-key', {
             describe: 'api key if target node requires authentication'
           })
-          .option('host', {
+          .option('bhn-host', {
             describe: 'host of target bitcoin header node',
             default: 'localhost'
           })
-          .option('port', {
+          .option('bhn-port', {
             describe: 'port of target bitcoin header node if different from default bitcoin RPC port'
           })
-          .option('network', {
+          .option('bhn-network', {
             describe:
               'Bitcoin network the target node is running on. This option is useful if want to target default ports.',
             default: 'main'
           })
-          .option('protocol', {
+          .option('bhn-protocol', {
             describe: 'protocol where target bitcoin header node is running',
             default: 'http:'
           })

--- a/cli.js
+++ b/cli.js
@@ -18,16 +18,16 @@ const getStdin = require('get-stdin')
 const yargs = require('yargs')
 
 async function parseBaseUriAsync(baseUri) {
-  // if the value supplied in --server or in chainpoint-cli.config is invalid, exit
+  // if the value supplied in --node-uri or in chainpoint-cli.config is invalid, exit
   if (!utils.isValidUrl(baseUri)) {
-    console.error(`Invalid server - ${baseUri}`)
+    console.error(`Invalid node uri - ${baseUri}`)
     process.exit(1)
   }
-  // if no value was specified in --server or in cli.config, let the chainpint-client select node(s)
+  // if no value was specified in --node-uri or in cli.config, let the chainpint-client select node(s)
   // http://0.0.0.0 is the env default, and represents a null setting
   if (baseUri === 'http://0.0.0.0') return null
 
-  // otherwise, return the valid value supplied with --server or in cli.config as a one element array
+  // otherwise, return the valid value supplied with --node-uri or in cli.config as a one element array
   return baseUri
 }
 
@@ -60,7 +60,6 @@ async function startAsync() {
       yargs.showHelp()
       console.error(`Error reading from stdin: ${input}`)
     }
-
     let argv = yargs
       .usage(
         'Usage: ' +
@@ -70,11 +69,11 @@ async function startAsync() {
             .slice(0, -3) +
           ' <command> [options] <argument>'
       )
-      .option('s', {
-        alias: 'server',
+      .option('n', {
+        alias: 'node-uri',
         requiresArg: true,
         default: env.CHAINPOINT_NODE_API_BASE_URI,
-        description: 'specify server to use',
+        description: 'specify uri of chainpoint node',
         type: 'string'
       })
       .option('q', {
@@ -93,7 +92,7 @@ async function startAsync() {
       })
       .command('submit', 'submit a hash to be anchored (3x Nodes default)', async yargs => {
         let argv = yargs.usage('Usage: submit [options] (<hash> <hash>... | <hash>,<hash>,... )').string('_').argv
-        argv.server = await parseBaseUriAsync(argv.server)
+        argv.nodeUri = await parseBaseUriAsync(argv.nodeUri)
         submitCmd.executeAsync(yargs, argv)
       })
       .command('update', 'retrieve an updated proof for your hash(es), if available', async yargs => {

--- a/lib/bhn/utils/getConfig.js
+++ b/lib/bhn/utils/getConfig.js
@@ -1,10 +1,11 @@
 const Config = require('bcfg')
 
-module.exports = function getConfig(options = {}) {
+module.exports = function getConfig(_options = {}) {
   const config = new Config('bhn')
   config.inject({ prefix: '~/.chainpoint/bhn' })
-
   // options passed are actually argv parsed by yargs
+  // but we need to get the bhn specific args but with the `bhn-` prefix parsed out
+  const options = parseBhnArgv(_options)
   config.inject(options)
   config.load({
     // Parse URL hash
@@ -20,4 +21,18 @@ module.exports = function getConfig(options = {}) {
   // can change the prefix by passing in a `prefix` option
   config.open('bhn.conf')
   return config
+}
+
+// utility function for parsing argvs and returning bhn options but without
+// the `bhn-` prefix
+function parseBhnArgv(argv) {
+  const options = {}
+  const prefix = 'bhn-'
+  for (let arg in argv) {
+    if (arg.includes(prefix)) {
+      let key = arg.slice(prefix.length)
+      options[key] = argv[arg]
+    }
+  }
+  return options
 }

--- a/lib/submit.js
+++ b/lib/submit.js
@@ -29,7 +29,7 @@ async function executeAsync(yargs, argv) {
   let json = argv.json || false
 
   // determine API base URI to use
-  let baseURI = argv.server
+  let baseURI = argv.nodeUri
 
   let argCount = argv._.length
 
@@ -74,8 +74,7 @@ async function executeAsync(yargs, argv) {
   // The /hashes endpoint will only accept POST_HASHES_MAX hashes per request
   // if hashes contains more than POST_HASHES_MAX hashes, break the set up into multiple requests
   let workingHashSet = hashes.slice()
-  while (workingHashSet.length > 0)
-    hashSegments.push(workingHashSet.splice(0, POST_HASHES_MAX))
+  while (workingHashSet.length > 0) hashSegments.push(workingHashSet.splice(0, POST_HASHES_MAX))
 
   for (let x = 0; x < hashSegments.length; x++) {
     submitTasks.push(async () => {
@@ -157,10 +156,7 @@ async function submitHashesAsync(hashDb, hashArray, baseURI) {
         hashItem.hash.length
       ].join(':')
       h.update(Buffer.from(hashStr))
-      let expectedData = Buffer.concat([
-        Buffer.from([0x01]),
-        h.digest()
-      ]).toString('hex')
+      let expectedData = Buffer.concat([Buffer.from([0x01]), h.digest()]).toString('hex')
       let embeddedData = hashItem.hashIdNode.slice(24)
       if (embeddedData === expectedData) {
         // the BLAKE2 hash has been validated
@@ -175,9 +171,7 @@ async function submitHashesAsync(hashDb, hashArray, baseURI) {
       submitResult.success = blakeValid
       submitResult.hash_id_node = hashItem.hashIdNode
       submitResult.hash = hashItem.hash
-      submitResult.message = blakeValid
-        ? 'submitted'
-        : 'refused, bad blake2 value in uuid from node'
+      submitResult.message = blakeValid ? 'submitted' : 'refused, bad blake2 value in uuid from node'
       submitResults.push(submitResult)
     } catch (error) {
       let submitResult = {}


### PR DESCRIPTION
* `--server` and `-s` changed to `--node-uri` and `-n` respectively for connecting to a chainpoint node
* all bhn related configs must be prefixed with `--bhn-` to be passed to the bhn client for connecting with a bhn node
* added a section to the readme for "backwards incompatible" api changes